### PR TITLE
Print pretty errors.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export async function preprocessLess(
     return { code: css, map };
   } catch (err) {
     const { line, column, index: character, extract } = err;
+    if (!(line && column && extract)) throw err;
 
     const frame = extract.map((l, i) => `${(line - 1) + i}:${l}`);
     frame.splice(2, 0, '^'.padStart(column + line.toString().length + 2));

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,20 @@ b { color: @color }`,
 `);
 });
 
+test('preprocessLess should format errors correctly', async t => {
+  const error = await t.throws(preprocessLess({}, {}, {
+    attributes: { lang: 'less' },
+    filename: './src/components/App.html',
+    content: `b {
+  color: @color
+}`,
+}));
+
+  t.is(error.frame, '1:b {\n2:  color: @color\n           ^\n3:}');
+  t.deepEqual(error.start, { line: 2, column: 9, character: 13 });
+  t.is(error.start, error.end);
+});
+
 test('less should return a function', async t => {
   t.is(typeof less(), 'function')
 });

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ test('preprocessLess should format errors correctly', async t => {
     content: `b {
   color: @color
 }`,
-}));
+  }));
 
   t.is(error.frame, '1:b {\n2:  color: @color\n           ^\n3:}');
   t.deepEqual(error.start, { line: 2, column: 9, character: 13 });


### PR DESCRIPTION
Svelte expects `frame` and `start` properties on an error object to display it properly. This pull request maps the  `line` `column` `index` and `extract` properties that `less` provides to the error format that `svelte` expects.